### PR TITLE
wilderness lines: minor amendments to multi areas

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 }
 
 group = 'at.nightfirec.wildernesslines'
-version = '1.3.2'
+version = '1.3.3'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/at/nightfirec/wildernesslines/WildernessLinesPlugin.java
+++ b/src/main/java/at/nightfirec/wildernesslines/WildernessLinesPlugin.java
@@ -65,7 +65,7 @@ public class WildernessLinesPlugin extends Plugin
 		new Rectangle(3200, 3904, 192, 64), // Northeast p2p wilderness
 		new Rectangle(3152, 3752, 176, 88), // North-mid east f2p wilderness
 		new Rectangle(3192, 3525, 136, 227), // East f2p wilderness
-		new Rectangle(3328, 3525, 17, 18), // Small east f2p wilderness strip NE of lumberyard
+		new Rectangle(3328, 3525, 17, 8), // Small east f2p wilderness strip NE of lumberyard
 		new Rectangle(3191, 3689, 1, 1), // One silly tile that used to be a BH "singles" lure spot
 		new Rectangle(3136, 3525, 56, 59), // Wilderness north of Grand Exchange
 		new Rectangle(3152, 3584, 40, 36), // SE of Ferox 1

--- a/src/main/java/at/nightfirec/wildernesslines/WildernessLinesPlugin.java
+++ b/src/main/java/at/nightfirec/wildernesslines/WildernessLinesPlugin.java
@@ -76,7 +76,8 @@ public class WildernessLinesPlugin extends Plugin
 		new Rectangle(3151, 3593, 1, 1), // SE of Ferox 2 extension 4
 		new Rectangle(3152, 3620, 10, 6), // SE of Ferox 3
 		new Rectangle(3187, 3620, 5, 28), // East of Ferox 1
-		new Rectangle(3176, 3636, 11, 12), // East of Ferox 2
+		new Rectangle(3179, 3636, 8, 4), // East of Ferox 2, south of bridge
+		new Rectangle(3176, 3640, 11, 8), // East of Ferox 2, bridge and north of bridge
 		new Rectangle(3174, 3647, 2, 1) // Two dumb tiles north of bridge east of Ferox
 	);
 	private static final int SPEAR_RANGE = 4;

--- a/src/main/java/at/nightfirec/wildernesslines/WildernessLinesPlugin.java
+++ b/src/main/java/at/nightfirec/wildernesslines/WildernessLinesPlugin.java
@@ -77,7 +77,7 @@ public class WildernessLinesPlugin extends Plugin
 		new Rectangle(3152, 3620, 10, 6), // SE of Ferox 3
 		new Rectangle(3187, 3620, 5, 28), // East of Ferox 1
 		new Rectangle(3176, 3636, 11, 12), // East of Ferox 2
-		new Rectangle(3175, 3647, 1, 1) // One dumb tile north of bridge east of Ferox
+		new Rectangle(3174, 3647, 2, 1) // Two dumb tiles north of bridge east of Ferox
 	);
 	private static final int SPEAR_RANGE = 4;
 	private static final Line2D[] TWENTY_LINES = {


### PR DESCRIPTION
There have, at some point, been changes to a few multi-combat areas. This PR intends to adjust those relevant areas so that the plugin accurately portrays the updated multi-combat areas. I was unfortunately unable to find any mentions by Jagex on blog posts or updates referencing these changes.

The amended areas:
<details>
  <summary>Odd tile north of the bridge, east of Ferox Enclave</summary>

![image](https://github.com/user-attachments/assets/b3d1e72f-3abe-4401-ba63-bc4556367789)
  
</details>
<details>
  <summary>Area south of the bridge, east of Ferox Enclave</summary>

![image](https://github.com/user-attachments/assets/32a77603-4e2d-47fc-8257-66cc9b15e5c3)
  
</details>
<details>
  <summary>Area north-east of lumberyard</summary>

![image](https://github.com/user-attachments/assets/3c9491f1-1e5b-4d22-b875-1fee79c50adb)
  
</details>