### PR TITLE
Change the "Congratulations level up text color" to indigo

### DIFF
--- a/src/main/java/at/nightfirec/virtuallevelups/VirtualLevelUpsInterfaceInput.java
+++ b/src/main/java/at/nightfirec/virtuallevelups/VirtualLevelUpsInterfaceInput.java
@@ -90,7 +90,7 @@ class VirtualLevelUpsInterfaceInput extends ChatboxInput implements KeyListener
 			levelUpLevelString = "Congratulations, you just advanced " + prefix + skillName + " level.";
 		}
 		levelUpLevel.setText(levelUpLevelString);
-		levelUpLevel.setTextColor(Color.BLACK.getRGB());
+		levelUpLevel.setColor(new Color(0x2F2B85)); // Indigo
 		levelUpLevel.setFontId(FontID.QUILL_8);
 		levelUpLevel.setXPositionMode(WidgetPositionMode.ABSOLUTE_TOP);
 		levelUpLevel.setOriginalX(73 + X_OFFSET);


### PR DESCRIPTION
It was bothering me that this wasn't matching the native color of the Congratulations method, so I found the color via a color picker tool off of a native screenshot and then replaced the line.